### PR TITLE
Remove unused RouterInterface parameter

### DIFF
--- a/src/Action/StaticPagesAction.php
+++ b/src/Action/StaticPagesAction.php
@@ -15,11 +15,6 @@ class StaticPagesAction implements ServerMiddlewareInterface
     const TEMPLATE_NS = 'static-pages';
 
     /**
-     * @var RouterInterface
-     */
-    private $router;
-
-    /**
      * @var TemplateRendererInterface
      */
     private $template;
@@ -29,9 +24,8 @@ class StaticPagesAction implements ServerMiddlewareInterface
      * @param RouterInterface $router
      * @param TemplateRendererInterface|null $template
      */
-    public function __construct(RouterInterface $router, TemplateRendererInterface $template = null)
+    public function __construct(TemplateRendererInterface $template = null)
     {
-        $this->router   = $router;
         $this->template = $template;
     }
 

--- a/src/Action/StaticPagesFactory.php
+++ b/src/Action/StaticPagesFactory.php
@@ -10,11 +10,10 @@ class StaticPagesFactory
 {
     public function __invoke(ContainerInterface $container)
     {
-        $router   = $container->get(RouterInterface::class);
         $template = $container->has(TemplateRendererInterface::class)
             ? $container->get(TemplateRendererInterface::class)
             : null;
 
-        return new StaticPagesAction($router, $template);
+        return new StaticPagesAction($template);
     }
 }

--- a/test/Action/StaticPagesActionTest.php
+++ b/test/Action/StaticPagesActionTest.php
@@ -32,14 +32,13 @@ class StaticPagesActionTest extends TestCase
     public function testDoesRequestCorrectTemplate($routeName, $templateName)
     {
         $delegate = $this->prophet->prophesize(DelegateInterface::class);
-        $router = $this->prophet->prophesize(RouterInterface::class);
         $template = $this->prophet->prophesize(TemplateRendererInterface::class);
         $template
             ->render($templateName)
             ->shouldBeCalledTimes(1)
             ->willReturn('<html></html>');
 
-        $action = new StaticPagesAction($router->reveal(), $template->reveal());
+        $action = new StaticPagesAction($template->reveal());
 
         $routeResult = $this->prophet->prophesize(RouteResult::class);
         $routeResult->getMatchedRouteName()


### PR DESCRIPTION
As pointed out by @froschdesign in #2 the `RouterInterface` parameter to [`StaticPagesAction`'s constructor](https://github.com/zfmastery/ze-static-pages/blob/master/src/Action/StaticPagesAction.php#L32) was only used in the constructor, nowhere else. Given that, it's being removed. Thanks for spotting it and raising an issue.